### PR TITLE
Add REST API to create L2VPN PTP

### DIFF
--- a/app/convert_topology.py
+++ b/app/convert_topology.py
@@ -17,6 +17,9 @@ class ParseConvertTopology:
         self.oxp_name = args['oxp_name']
         self.oxp_url = args['oxp_url']
         self.oxp_urls_list = args['oxp_urls_list']
+        # mapping from Kytos to SDX and vice-versa
+        self.kytos2sdx = {}
+        self.sdx2kytos = {}
 
     def get_kytos_nodes(self) -> dict:
         """ return parse_args["topology"]["switches"] values """
@@ -161,6 +164,8 @@ class ParseConvertTopology:
             port_no = interface["port_number"]
             if port_no != 4294967294:
                 ports.append(self.get_port(sdx_node_name, interface))
+                self.kytos2sdx[interface["id"]] = ports[-1]["id"]
+                self.sdx2kytos[ports[-1]["id"]] = interface["id"]
 
         return ports
 
@@ -409,4 +414,6 @@ class ParseConvertTopology:
         topology["links"] = self.get_sdx_links()
         topology["links"] += self.create_inter_oxp_link_entries()
         topology["services"] = ["l2vpn-ptp"]
+        topology["kytos2sdx"] = self.kytos2sdx
+        topology["sdx2kytos"] = self.sdx2kytos
         return topology

--- a/app/settings.py
+++ b/app/settings.py
@@ -32,3 +32,6 @@ OPERATIONAL_EVENTS = [
         # '.*.switch.interface.link_up',
         # '.*.switch.(new|reconnected)'
         ]
+
+# Kytos mef_eline endpoint for creating L2VPN PTP
+KYTOS_EVC_URL = "http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/"


### PR DESCRIPTION
Fixes #31 

## Description of the change

1. As we discussed on the All Hands Meeting back in Feb 2024, since the port ID is something internal to the OXPO and SDX-Controller will have only the port IDs according to the semantics defined on the Data Model Topology, we decided to augment the role and responsibility of the sdx-kytos-topology Napp to also receives the connection creation requests from SDX-LC (requests to create L2VPN point-to-point)
2. The changes on this PR implements a prototype to work along with SDX-LC to create Connections/L2VPN-PTP

## Local tests

Tested changing the KYTOS URL on SDX-LC docker-compose to define the KYTOS_PROVISION URL pointing to this API endpoint instead of mef_eline's original endpoint (which won't fully understand the UNIs -- since they come on SDX naming convention)