### PR TITLE
Adjusting OpenAPI spec according to reviews from Jeronimo

### DIFF
--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -545,7 +545,7 @@ components:
           type: string
           minLength: 5
           maxLength: 5
-          pattern: '^[A-Z]{2}-[A-Z]{2}$'
+          pattern: '^[A-Z]{2}-[a-zA-Z0-9]{1,3}$'
         private:
           type: array
           items:

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -532,6 +532,7 @@ components:
       properties:
         address:
           type: string
+          maxLength: 255
         latitude:
           type: number
           minimum: -90.0

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -526,6 +526,7 @@ components:
           type: array
           items:
             type: string
+            enum: ['mtu', 'status', 'state', 'services']
 
     Location: # Can be referenced via '#/components/schemas/Location'
       type: object
@@ -553,6 +554,7 @@ components:
           type: array
           items:
             type: string
+            enum: ['address', 'latitude', 'longitude', 'iso3166_2_lvl4']
 
     Link: # Can be referenced via '#/components/schemas/Link'
       type: object
@@ -610,3 +612,4 @@ components:
           type: array
           items:
             type: string
+            enum: ['residual_bandwidth', 'latency', 'packet_loss']

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -528,6 +528,7 @@ components:
         - address
         - latitude
         - longitude
+        - iso3166_2_lvl4
       properties:
         address:
           type: string

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -247,6 +247,7 @@ components:
       properties:
         name:
           type: string
+          maxLength: 50
         endpoints:
           type: array
           minItems: 2
@@ -323,7 +324,7 @@ components:
         - port_id
         - vlan
       properties:
-        port_uri:
+        port_id:
           type: string
         vlan:
           type: string

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -494,10 +494,6 @@ components:
         state:
           type: string
           enum: ['enabled', 'disabled', 'maintenance']
-        label_range:
-          type: array
-          items:
-            type: string
         services:
           items:
             type: object

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -326,7 +326,7 @@ components:
       properties:
         port_id:
           type: string
-          pattern: '^urn:sdx:port:[A-Za-z0-9_.,/-]*$'
+          pattern: '^urn:sdx:port:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*$'
         vlan:
           type: string
           pattern: '^(any|untagged|all|[0-9]+:[0-9]+|[0-9]+)$'
@@ -577,25 +577,31 @@ components:
           maxItems: 2
           items:
             type: string
+            pattern: '^urn:sdx:port:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*$'
         type:
           type: string
           enum: ['intra']
         bandwidth:
           type: number
           format: float
+          minimum: 0
         residual_bandwidth:
-          type: integer
+          type: number
+          format: float
           minimum: 0
           maximum: 100
         latency:
           type: number
           format: float
+          minimum: 0
         packet_loss:
-          type: integer
+          type: number
+          format: float
           minimum: 0
           maximum: 100
         availability:
-          type: integer
+          type: number
+          format: float
           minimum: 0
           maximum: 100
         status:

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -326,6 +326,7 @@ components:
       properties:
         port_id:
           type: string
+          pattern: '^urn:sdx:port:[A-Za-z0-9_.,/-]*$'
         vlan:
           type: string
           pattern: '^(any|untagged|all|[0-9]+:[0-9]+|[0-9]+)$'

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -432,7 +432,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '^urn:sdx:node:[A-Za-z0-9.,_/-]*$'
+          pattern: '^urn:sdx:node:[A-Za-z0-9_,./-]*:[A-Za-z0-9.,_/-]*$'
         name:
           type: string
           maxLength: 30
@@ -470,7 +470,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '^urn:sdx:port:[A-Za-z0-9_.,/-]*$'
+          pattern: '^urn:sdx:port:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*$'
         name:
           type: string
           maxLength: 30
@@ -566,7 +566,7 @@ components:
       properties:
         id:
           type: string
-          pattern: '^urn:sdx:link:[A-Za-z0-9_.,/-]*$'
+          pattern: '^urn:sdx:link:[A-Za-z0-9_,./-]*:[A-Za-z0-9_.,/-]*$'
         name:
           type: string
           maxLength: 30

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -486,8 +486,6 @@ components:
           format: int32
           minimum: 1500
           maximum: 10000
-        short_name:
-          type: string
         nni:
           type: string
         status:

--- a/app/openapi.yml
+++ b/app/openapi.yml
@@ -417,9 +417,9 @@ components:
               $ref: '#/components/schemas/Link'
           services:
             type: array
-            minItems: 1
             items:
               type: string
+              enum: ['l2vpn-ptp', 'l2vpn-ptmp']
 
     Node: # Can be referenced via '#/components/schemas/Node'
       type: object
@@ -456,10 +456,6 @@ components:
             - enabled  # the node is in administrative enabled mode
             - disabled  # the node is in administrative disabled mode
             - maintenance  #  the node is under maintenance (not available for use)
-        private:
-          type: array
-          items:
-            type: string
 
     Port: # Can be referenced via '#/components/schemas/Port'
       type: object


### PR DESCRIPTION
Adjusting OpenAPI spec according to reviews from Jeronimo:
- _Name is limit to 50 chars. No limit imposed_: Fixed
- _The correct name is port_id not port_uri. port_id should regex to start “^urn:sdx:port:”_: Fixed
- _VLAN  should not accept vlan 0 and in case of range, left side should be smaller than right side. It can be left to the implementation_: left to the implementation
- _model_version should be set to 2.0.0_: left to the implementation
- _services attribute is a list of strings and optional. The version 2.0.0 only accepts values "l2vpn-ptp" and "l2vpn-ptmp". If the services attribute is not provided or provided as empty:_ Fixed
- _Node doesn’t have private attributes_: Fixed (reverted #59)
- _remove short_name_ : Fixed
- making Iso3166_2_lvl4 mandatory
- removing label_range
- adding size limit to Location.address (255 chars)
- fix regex for port id and change Link attributes to use number/float and define minimum value for some of them
- adding OXP domain name into Port, Node, Link id regexeps
- adjust regex for Iso3166_2_lvl4 to allow second part with a string of up to three alphanumeric characters